### PR TITLE
Inference

### DIFF
--- a/abstract-interpretation.cabal
+++ b/abstract-interpretation.cabal
@@ -25,6 +25,7 @@ library
                      , Abstract.Store
                      , Abstract.Syntax
                      , Abstract.Type
+                     , Abstract.Util
                      , Abstract.Value
                      , Control.Effect
                      , Control.Monad.Effect.Failure

--- a/src/Abstract/Interpreter.hs
+++ b/src/Abstract/Interpreter.hs
@@ -4,11 +4,11 @@ module Abstract.Interpreter where
 import Abstract.Primitive
 import Abstract.Store
 import Abstract.Syntax
+import Abstract.Type
 import Abstract.Value
 import Control.Effect
 import Control.Monad.Effect hiding (run)
 import Control.Monad.Effect.Failure
-import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Reader
 import Control.Monad.Effect.State
 import Data.Function (fix)

--- a/src/Abstract/Interpreter.hs
+++ b/src/Abstract/Interpreter.hs
@@ -8,6 +8,7 @@ import Abstract.Value
 import Control.Effect
 import Control.Monad.Effect hiding (run)
 import Control.Monad.Effect.Failure
+import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Reader
 import Control.Monad.Effect.State
 import Data.Function (fix)
@@ -15,7 +16,7 @@ import Data.Semigroup
 import Prelude hiding (fail)
 
 
-type Interpreter l v = '[Failure, State (Store l v), Reader (Environment l v)]
+type Interpreter l v = '[Fresh, Failure, State (Store l v), Reader (Environment l v)]
 
 type MonadInterpreter l v m = (MonadEnv l v m, MonadStore l v m, MonadFail m)
 

--- a/src/Abstract/Interpreter.hs
+++ b/src/Abstract/Interpreter.hs
@@ -4,7 +4,6 @@ module Abstract.Interpreter where
 import Abstract.Primitive
 import Abstract.Store
 import Abstract.Syntax
-import Abstract.Type
 import Abstract.Value
 import Control.Effect
 import Control.Monad.Effect hiding (run)
@@ -16,7 +15,7 @@ import Data.Semigroup
 import Prelude hiding (fail)
 
 
-type Interpreter l v = '[Fresh, Failure, State (Store l v), Reader (Environment l v)]
+type Interpreter l v = '[Failure, State (Store l v), Reader (Environment l v)]
 
 type MonadInterpreter l v m = (MonadEnv l v m, MonadStore l v m, MonadFail m)
 

--- a/src/Abstract/Interpreter.hs
+++ b/src/Abstract/Interpreter.hs
@@ -49,8 +49,8 @@ ev ev term = case out term of
     closure <- ev e0
     v1 <- ev e1
     app @l ev closure v1
-  Lam x ty e0 -> lambda @l ev x ty e0
-  Rec x ty e0 -> rec @l ev x ty e0
+  Lam x e0 -> lambda @l ev x e0
+  Rec x e0 -> rec @l ev x e0
   If c t e -> do
     v <- ev c
     c' <- truthy v

--- a/src/Abstract/Interpreter/Caching.hs
+++ b/src/Abstract/Interpreter/Caching.hs
@@ -7,12 +7,12 @@ import Abstract.Interpreter.Collecting
 import Abstract.Primitive
 import Abstract.Set
 import Abstract.Store
+import Abstract.Type
 import Abstract.Syntax
 import Abstract.Value
 import Control.Applicative
 import Control.Effect
 import Control.Monad.Effect.Failure
-import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal hiding (run)
 import Control.Monad.Effect.NonDetEff
 import Control.Monad.Effect.Reader

--- a/src/Abstract/Interpreter/Caching.hs
+++ b/src/Abstract/Interpreter/Caching.hs
@@ -109,7 +109,7 @@ evCache ev0 ev e = do
       return v
 
 fixCache :: forall l t v m
-         .  (Ord l, Ord t, Ord v, Ord1 (Cell l), MonadCachingInterpreter l t v m, MonadNonDet m)
+         .  (Ord l, Ord t, Ord v, Ord1 (Cell l), MonadCachingInterpreter l t v m, MonadNonDet m, MonadFresh m)
          => Eval t (m v)
          -> Eval t (m v)
 fixCache eval e = do
@@ -120,6 +120,7 @@ fixCache eval e = do
   pairs <- mlfp mempty (\ dollar -> do
     putCache (mempty :: Cache l t v)
     putStore store
+    reset 0
     _ <- localCache (const dollar) (collect point (eval e) :: m (Set v))
     getCache)
   asum . flip map (maybe [] toList (cacheLookup c pairs)) $ \ (value, store') -> do

--- a/src/Abstract/Interpreter/Caching.hs
+++ b/src/Abstract/Interpreter/Caching.hs
@@ -12,6 +12,7 @@ import Abstract.Value
 import Control.Applicative
 import Control.Effect
 import Control.Monad.Effect.Failure
+import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal hiding (run)
 import Control.Monad.Effect.NonDetEff
 import Control.Monad.Effect.Reader
@@ -39,7 +40,7 @@ cacheInsert :: (Ord l, Ord t, Ord v, Ord1 (Cell l)) => Configuration l t v -> (v
 cacheInsert = (((Cache .) . (. unCache)) .) . (. point) . Map.insertWith (<>)
 
 
-type CachingInterpreter l t v = '[Reader (Set (Address l v)), Reader (Environment l v), Failure, NonDetEff, State (Store l v), Reader (Cache l t v), State (Cache l t v)]
+type CachingInterpreter l t v = '[Fresh, Reader (Set (Address l v)), Reader (Environment l v), Failure, NonDetEff, State (Store l v), Reader (Cache l t v), State (Cache l t v)]
 
 type CachingResult l t v = Final (CachingInterpreter l t v) v
 

--- a/src/Abstract/Primitive.hs
+++ b/src/Abstract/Primitive.hs
@@ -97,30 +97,28 @@ instance (MonadFail m, Alternative m) => MonadPrim Type m where
   delta1 _   Int  = pure Int
   delta1 _   _    = nonNumeric
 
-  delta2 And       Bool Bool = pure Bool
-  delta2 And       _    _    = nonBoolean
-  delta2 Or        Bool Bool = pure Bool
-  delta2 Or        _    _    = nonBoolean
-  delta2 Eq        Bool Bool = pure Bool
-  delta2 Eq        Int  Int  = pure Bool
-  delta2 Eq        _    _    = disjointComparison
-  delta2 Lt        Bool Bool = pure Bool
-  delta2 Lt        Int  Int  = pure Bool
-  delta2 Lt        _    _    = disjointComparison
-  delta2 LtE       Bool Bool = pure Bool
-  delta2 LtE       Int  Int  = pure Bool
-  delta2 LtE       _    _    = disjointComparison
-  delta2 Gt        Bool Bool = pure Bool
-  delta2 Gt        Int  Int  = pure Bool
-  delta2 Gt        _    _    = disjointComparison
-  delta2 GtE       Bool Bool = pure Bool
-  delta2 GtE       Int  Int  = pure Bool
-  delta2 GtE       _    _    = disjointComparison
+  delta2 o a b
+    | o `elem` booleanOperators = case (a, b) of
+      (Bool,   Bool)   -> pure Bool
+      (TVar _, Bool)   -> pure Bool
+      (Bool,   TVar _) -> pure Bool
+      (TVar _, TVar _) -> pure Bool
+      _                -> nonBoolean
+    | o `elem` relationOperators = case (a, b) of
+      _ | a == b       -> pure Bool
+      (TVar _, _)      -> pure Bool
+      (_,      TVar _) -> pure Bool
+      _                -> disjointComparison
+    | o `elem` arithmeticOperators = case (a, b) of
+      (Int,    Int)    -> pure Int
+      (TVar _, Int)    -> pure Int
+      (Int,    TVar _) -> pure Int
+      (TVar _, TVar _) -> pure Int
+      _                -> nonNumeric
   delta2 DividedBy Int  Int  = pure Int <|> divisionByZero
   delta2 Quotient  Int  Int  = pure Int <|> divisionByZero
   delta2 Remainder Int  Int  = pure Int <|> divisionByZero
   delta2 Modulus   Int  Int  = pure Int <|> divisionByZero
-  delta2 _         Int  Int  = pure Int
   delta2 _         _    _    = nonNumeric
 
   truthy Bool = pure True <|> pure False

--- a/src/Abstract/Primitive.hs
+++ b/src/Abstract/Primitive.hs
@@ -121,8 +121,9 @@ instance (MonadFail m, Alternative m) => MonadPrim Type m where
   delta2 Modulus   Int  Int  = pure Int <|> divisionByZero
   delta2 _         _    _    = nonNumeric
 
-  truthy Bool = pure True <|> pure False
-  truthy _    = nonBoolean
+  truthy Bool     = pure True <|> pure False
+  truthy (TVar _) = pure True <|> pure False
+  truthy _        = nonBoolean
 
 
 instance Num Prim where

--- a/src/Abstract/Primitive.hs
+++ b/src/Abstract/Primitive.hs
@@ -14,6 +14,15 @@ data Op1 = Negate | Abs | Signum | Not
 data Op2 = Plus | Minus | Times | DividedBy | Quotient | Remainder | Modulus | And | Or | Eq | Lt | LtE | Gt | GtE
   deriving (Eq, Ord, Show)
 
+arithmeticOperators :: [Op2]
+arithmeticOperators = [Plus, Minus, Times, DividedBy, Quotient, Remainder, Modulus]
+
+booleanOperators :: [Op2]
+booleanOperators = [And, Or]
+
+relationOperators :: [Op2]
+relationOperators = [Eq, Lt, LtE, Gt, GtE]
+
 
 data Prim
   = PInt  {-# UNPACK #-} !Int

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE FlexibleContexts, TypeOperators, UndecidableInstances #-}
 module Abstract.Type where
 
+import Control.Monad.Effect
+import Control.Monad.Effect.Fresh as Fresh
 import Data.Text.Prettyprint.Doc
 
 type TName = Int
@@ -10,6 +13,9 @@ data Type = Int | Bool | Type :-> Type | Type :* Type | TVar TName
 
 class Monad m => MonadFresh m where
   fresh :: m TName
+
+instance Fresh :< fs => MonadFresh (Eff fs) where
+  fresh = Fresh.fresh
 
 
 instance Pretty Type where

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -8,5 +8,9 @@ data Type = Int | Bool | Type :-> Type | Type :* Type | TVar TName
   deriving (Eq, Ord, Show)
 
 
+class Monad m => MonadFresh m where
+  fresh :: m TName
+
+
 instance Pretty Type where
   pretty = pretty . show

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -2,7 +2,7 @@ module Abstract.Type where
 
 import Data.Text.Prettyprint.Doc
 
-type TName = String
+type TName = Int
 
 data Type = Int | Bool | Type :-> Type | Type :* Type | TVar TName
   deriving (Eq, Ord, Show)

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -17,6 +17,7 @@ data Type = Int | Bool | Type :-> Type | Type :* Type | TVar TName
 unify :: MonadFail m => Type -> Type -> m Type
 unify Int  Int  = pure Int
 unify Bool Bool = pure Bool
+unify (a1 :-> b1) (a2 :-> b2) = (:->) <$> unify a1 a2 <*> unify b1 b2
 unify t1 t2 = fail ("cannot unify " ++ prettyString t1 ++ " with " ++ prettyString t2)
 
 

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -19,6 +19,8 @@ unify Int  Int  = pure Int
 unify Bool Bool = pure Bool
 unify (a1 :-> b1) (a2 :-> b2) = (:->) <$> unify a1 a2 <*> unify b1 b2
 unify (a1 :* b1)  (a2 :* b2)  = (:*)  <$> unify a1 a2 <*> unify b1 b2
+unify (TVar _) b = pure b
+unify a (TVar _) = pure a
 unify t1 t2 = fail ("cannot unify " ++ prettyString t1 ++ " with " ++ prettyString t2)
 
 

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -2,7 +2,9 @@ module Abstract.Type where
 
 import Data.Text.Prettyprint.Doc
 
-data Type = Int | Bool | Type :-> Type | Type :* Type
+type TName = String
+
+data Type = Int | Bool | Type :-> Type | Type :* Type | TVar TName
   deriving (Eq, Ord, Show)
 
 

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -1,14 +1,23 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, GADTs, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Abstract.Type where
 
+import Abstract.Util
 import Control.Effect
 import Control.Monad.Effect.Internal
+import Control.Monad.Fail
 import Data.Text.Prettyprint.Doc
+import Prelude hiding (fail)
 
 type TName = Int
 
 data Type = Int | Bool | Type :-> Type | Type :* Type | TVar TName
   deriving (Eq, Ord, Show)
+
+
+unify :: MonadFail m => Type -> Type -> m Type
+unify Int  Int  = pure Int
+unify Bool Bool = pure Bool
+unify t1 t2 = fail ("cannot unify " ++ prettyString t1 ++ " with " ++ prettyString t2)
 
 
 data Fresh a where

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE FlexibleContexts, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, GADTs, MultiParamTypeClasses, TypeOperators, UndecidableInstances #-}
 module Abstract.Type where
 
-import Control.Monad.Effect
-import Control.Monad.Effect.Fresh as Fresh
+import Control.Effect
+import Control.Monad.Effect.Internal
 import Data.Text.Prettyprint.Doc
 
 type TName = Int
@@ -11,12 +11,22 @@ data Type = Int | Bool | Type :-> Type | Type :* Type | TVar TName
   deriving (Eq, Ord, Show)
 
 
+data Fresh a where
+  Reset :: Int -> Fresh ()
+  Fresh :: Fresh Int
+
 class Monad m => MonadFresh m where
   fresh :: m TName
 
 instance Fresh :< fs => MonadFresh (Eff fs) where
-  fresh = Fresh.fresh
+  fresh = send Fresh
 
 
 instance Pretty Type where
   pretty = pretty . show
+
+
+instance RunEffect Fresh a where
+  runEffect = relayState (0 :: Int) (const pure) (\ s action k -> case action of
+    Fresh -> k (succ s) s
+    Reset s' -> k s' ())

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -18,6 +18,7 @@ unify :: MonadFail m => Type -> Type -> m Type
 unify Int  Int  = pure Int
 unify Bool Bool = pure Bool
 unify (a1 :-> b1) (a2 :-> b2) = (:->) <$> unify a1 a2 <*> unify b1 b2
+unify (a1 :* b1)  (a2 :* b2)  = (:*)  <$> unify a1 a2 <*> unify b1 b2
 unify t1 t2 = fail ("cannot unify " ++ prettyString t1 ++ " with " ++ prettyString t2)
 
 

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -27,6 +27,6 @@ instance Pretty Type where
 
 
 instance RunEffect Fresh a where
-  runEffect = relayState (0 :: Int) (const pure) (\ s action k -> case action of
+  runEffect = relayState (0 :: TName) (const pure) (\ s action k -> case action of
     Fresh -> k (succ s) s
     Reset s' -> k s' ())

--- a/src/Abstract/Type.hs
+++ b/src/Abstract/Type.hs
@@ -17,9 +17,11 @@ data Fresh a where
 
 class Monad m => MonadFresh m where
   fresh :: m TName
+  reset :: TName -> m ()
 
 instance Fresh :< fs => MonadFresh (Eff fs) where
   fresh = send Fresh
+  reset = send . Reset
 
 
 instance Pretty Type where

--- a/src/Abstract/Util.hs
+++ b/src/Abstract/Util.hs
@@ -1,1 +1,7 @@
 module Abstract.Util where
+
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.String
+
+prettyString :: Pretty a => a -> String
+prettyString a = renderString (layoutPretty (LayoutOptions { layoutPageWidth = AvailablePerLine 100 1 }) (unAnnotate (pretty a)))

--- a/src/Abstract/Util.hs
+++ b/src/Abstract/Util.hs
@@ -1,0 +1,1 @@
+module Abstract.Util where

--- a/src/Abstract/Value.hs
+++ b/src/Abstract/Value.hs
@@ -93,10 +93,10 @@ instance (MonadStore Monovariant Type m, MonadEnv Monovariant Type m, MonadFail 
     outTy <- localEnv (envInsert name (a :: Address Monovariant Type)) (ev body)
     return (TVar tvar :-> outTy)
 
-  app _ (inTy :-> outTy) argTy = do
-    unless (inTy == argTy) (fail ("expected " ++ show inTy ++ " but got " ++ show argTy))
+  app _ opTy inTy = do
+    tvar <- fresh
+    _ :-> outTy <- opTy `unify` (inTy :-> TVar tvar)
     return outTy
-  app _ op _ = fail $ "non-function operator: " ++ show op
 
 instance AbstractValue Monovariant Type where
   valueRoots _ = mempty

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -4,7 +4,6 @@ module Control.Effect where
 import Abstract.Set
 import qualified Control.Monad.Effect as Effect
 import Control.Monad.Effect.Failure
-import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal hiding (run)
 import Control.Monad.Effect.NonDetEff
 import Control.Monad.Effect.Reader
@@ -53,6 +52,3 @@ instance Ord a => RunEffect NonDetEff a where
   runEffect = relay (pure . point) (\ m k -> case m of
     MZero -> pure mempty
     MPlus -> mappend <$> k True <*> k False)
-
-instance RunEffect Fresh a where
-  runEffect = flip runFresh' 0

--- a/src/Control/Effect.hs
+++ b/src/Control/Effect.hs
@@ -4,6 +4,7 @@ module Control.Effect where
 import Abstract.Set
 import qualified Control.Monad.Effect as Effect
 import Control.Monad.Effect.Failure
+import Control.Monad.Effect.Fresh
 import Control.Monad.Effect.Internal hiding (run)
 import Control.Monad.Effect.NonDetEff
 import Control.Monad.Effect.Reader
@@ -52,3 +53,6 @@ instance Ord a => RunEffect NonDetEff a where
   runEffect = relay (pure . point) (\ m k -> case m of
     MZero -> pure mempty
     MPlus -> mappend <$> k True <*> k False)
+
+instance RunEffect Fresh a where
+  runEffect = flip runFresh' 0


### PR DESCRIPTION
Really rough draft at polymorphic type inference. Unification is applied inconsistently and doesn’t build up a substitution, so this is almost certainly incomplete, but it suffices to infer most general unifiers for lambdas and recursive bindings.